### PR TITLE
fix plugin for Zeek v6.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 project(ZeekPluginXorExe)
 

--- a/zkg.meta
+++ b/zkg.meta
@@ -2,5 +2,6 @@
 description = A plugin to find Windows executables that have been XOR encoded.
 tags = plugin, pe, executable, malware
 plugin_dir = build
+script_dir = scripts
 build_command = ( ./configure && make )
 test_command = ( cd tests && btest -d )


### PR DESCRIPTION
Two changes:

* set `cmake_minimum_required` to 3.15 so that plugin loads with v6.1.0
* specify `script_dir` in zkg.meta to avoid `no __load__.zeek in implicit script_dir, skipped installing scripts`